### PR TITLE
Add TypeScript path alias recipe

### DIFF
--- a/code-quality/typescript-path-alias/fixes/javascript_default.md
+++ b/code-quality/typescript-path-alias/fixes/javascript_default.md
@@ -1,0 +1,99 @@
+# Setting up TypeScript Path Alias
+
+## TypeScript Configuration
+
+Add or update the `tsconfig.json` file with path mapping configuration:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  }
+}
+```
+
+If using a different source directory than `src/`, adjust the path mapping accordingly.
+
+## Build Tool Configuration
+
+### For Vite projects
+Add alias configuration to `vite.config.js` or `vite.config.ts`:
+
+```javascript
+import { defineConfig } from 'vite'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': path.resolve(__dirname, 'src')
+    }
+  }
+})
+```
+
+### For Webpack projects
+Add alias configuration to `webpack.config.js`:
+
+```javascript
+const path = require('path')
+
+module.exports = {
+  resolve: {
+    alias: {
+      '~': path.resolve(__dirname, 'src')
+    }
+  }
+}
+```
+
+## Update Existing Imports
+
+Find and replace all relative imports that navigate up from the source directory with the new alias:
+
+```bash
+# Find TypeScript files with relative imports going up from src
+find . -name "*.ts" -o -name "*.tsx" | xargs grep -l "\.\./.*" | grep -E "src/"
+```
+
+For each file found, replace imports that reference files outside the current directory structure with the alias:
+
+```typescript
+// Replace patterns like:
+import { Component } from '../../../components/Component'
+import { utils } from '../../utils/helpers'
+import config from '../../../config/app.config'
+
+// With:
+import { Component } from '~/components/Component'
+import { utils } from '~/utils/helpers' 
+import config from '~/config/app.config'
+```
+
+Focus on replacing imports that use `../` to navigate up to the source root level.
+
+## Verification
+
+Test the alias by verifying that imports resolve correctly:
+
+```typescript
+// Example of converted import
+import { Component } from '~/components/Component'
+```
+
+Ensure the TypeScript compiler and your build tool both resolve the alias correctly without errors. Run the TypeScript type checker to verify all imports resolve properly:
+
+```bash
+# First try the typecheck script if available
+npm run typecheck
+```
+
+If the project doesn't have a typecheck script in package.json, use TypeScript directly:
+
+```bash
+# Fallback to direct TypeScript type checking
+npx tsc --noEmit
+```

--- a/code-quality/typescript-path-alias/metadata.yaml
+++ b/code-quality/typescript-path-alias/metadata.yaml
@@ -1,0 +1,21 @@
+id: typescript-path-alias
+category: code-quality
+summary: Adds a top level path alias (~) to allow imports from the source's root
+level: project-only
+
+ecosystems:
+  - id: javascript
+    default_variant: default
+    variants:
+      - id: default
+        fix_prompt: fixes/javascript_default.md
+
+provides:
+  - typescript-path-alias.configured
+  - typescript-path-alias.alias_symbol
+
+requires:
+  - key: project.ecosystem
+    equals: javascript
+  - key: project.language
+    equals: typescript

--- a/code-quality/typescript-path-alias/prompt.md
+++ b/code-quality/typescript-path-alias/prompt.md
@@ -1,0 +1,30 @@
+## Goal
+
+Configure a top-level path alias (~) to enable clean imports from the project's source root directory.
+
+## Investigation
+
+1. **Check for existing TypeScript configuration**
+   - Look for tsconfig.json or tsconfig.*.json files in the project root
+   - Examine any existing "paths" configuration in compilerOptions
+   - Note the "baseUrl" setting if present
+
+2. **Identify source directory structure**
+   - Determine the main source directory (commonly src/, lib/, or project root)
+   - Check for existing import patterns in TypeScript files
+   - Identify the intended root for the alias mapping
+
+3. **Check bundler/build tool configuration**
+   - Look for webpack.config.js, vite.config.js, rollup.config.js, or similar build configuration
+   - Check if path aliases are already configured in the bundler
+   - Identify if additional bundler configuration is needed for the alias
+
+4. **Examine existing import statements**
+   - Review current relative import patterns (e.g., ../../../components)
+   - Check if any path aliases are already in use
+   - Identify files that would benefit from the alias
+
+## Expected Output
+
+- typescript-path-alias.configured: Whether the ~ path alias has been successfully set up
+- typescript-path-alias.alias_symbol: The symbol used for the alias (typically ~)


### PR DESCRIPTION
## Summary

Add a new TypeScript path alias recipe that configures a top-level path alias (~) to enable clean imports from the project's source root directory.

**Features:**
- Configures TypeScript path mapping in tsconfig.json
- Includes bundler configuration for Vite and Webpack projects
- Automatically updates existing TypeScript files to replace relative imports with the new alias
- Focuses on TypeScript files (.ts, .tsx) since JS files don't benefit from tsconfig path aliases
- Includes proper verification with typecheck script priority over direct tsc calls

**Recipe outputs:**
- `typescript-path-alias.configured`: Whether the ~ path alias has been successfully set up
- `typescript-path-alias.alias_symbol`: The symbol used for the alias (typically ~)

## Test plan

- [ ] Recipe validates correctly with `chorenzo recipes validate`
- [ ] Recipe applies successfully to TypeScript projects with existing relative imports
- [ ] Path alias configuration works in both tsconfig.json and bundler configs
- [ ] Import updates target only TypeScript files with `../` patterns
- [ ] Verification steps run successfully with both typecheck script and fallback tsc
- [ ] Recipe only applies to JavaScript ecosystem projects with TypeScript language