### PR TITLE
Update existing recipe provides lists to follow conservative principles

### DIFF
--- a/code-quality/typescript-path-alias/metadata.yaml
+++ b/code-quality/typescript-path-alias/metadata.yaml
@@ -12,7 +12,6 @@ ecosystems:
 
 provides:
   - typescript-path-alias.configured
-  - typescript-path-alias.alias_symbol
 
 requires:
   - key: project.ecosystem

--- a/code-quality/typescript-path-alias/prompt.md
+++ b/code-quality/typescript-path-alias/prompt.md
@@ -27,4 +27,3 @@ Configure a top-level path alias (~) to enable clean imports from the project's 
 ## Expected Output
 
 - typescript-path-alias.configured: Whether the ~ path alias has been successfully set up
-- typescript-path-alias.alias_symbol: The symbol used for the alias (typically ~)


### PR DESCRIPTION
## Summary

  Updates existing recipe provides lists to follow the conservative principles established in CHO-43. Reduces unnecessary provides variables that represent internal state rather than genuine infrastructure
  dependencies.

  ## Changes Made

  ### TypeScript Library Recipes Updated:

  1. **typescript-path-alias**: 2 → 1 provides (removed `alias_symbol`)

  ### Conservative Principles Applied:

  - ✅ Removed implementation details (`.alias_symbol`)
  - ✅ Kept only infrastructure state that other recipes genuinely depend on

  ## Impact

  - **Before**: 2 total provides variables across 1 typescript recipe
  - **After**: 1 total provides variable across 1 typescript recipe
  - **Reduction**: 50% fewer provides variables

  ## Files Modified

  - Updated metadata.yaml file to remove unnecessary provides
  - Updated prompt.md file to match new provides list
  - Kept `typescript-path-alias.configured` as build tools need to know about path aliases

  ## Test Plan

  - [ ] Validate updated recipe passes validation
  - [ ] Test recipe application with updated provides list